### PR TITLE
Build stable releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,34 @@
+
 language: bash
-os: linux
-sudo: enabled
+dist: xenial
+
 env:
   global:
     - LC_ALL: C.UTF-8
     - LANG: C.UTF-8
+    - SNAPCRAFT_ENABLE_SILENT_REPORT: y
+    - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
 
-install:
+addons:
+  snaps:
+    - name: snapcraft
+      channel: stable
+      classic: true
+    - name: http
+    - name: transfer
+    - name: lxd
+      channel: stable
+
+script:
   - sudo apt update
-  - sudo apt install -y snapd
-  - sudo snap install lxd --channel 3.0/stable
-  - sudo snap install snapcraft --candidate --classic
+  - sudo /snap/bin/lxd.migrate -yes
   - sudo /snap/bin/lxd waitready
   - sudo /snap/bin/lxd init --auto
   - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
-script:
-  - export PATH=/snap/bin:$PATH
-  - sudo snapcraft cleanbuild
-  - sudo cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - sudo snapcraft --use-lxd
 after_success:
-  - sudo snap install transfer
-  - timeout 180 sudo /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - timeout 180 /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
 after_failure:
   - sudo journalctl -u snapd
-  - sudo snap install http
-  - /snap/bin/http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
+  - http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,7 +114,7 @@ parts:
       - libglu1-mesa
       - libgtk2.0-0
       - libogg0
-      - libprotobuf9v5
+      - libprotobuf10
       - libpulse0
       - libqt5sql5-sqlite
       - libqt5xml5

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
       - CONFIG+=no-alsa no-oss no-server -recursive no-update packaged no-embed-qt-translations release bundled-celt symbols
     override-pull: |
       snapcraftctl pull
-      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag="$(git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags | tail -n 1)"
       last_released_tag="$(snap info mumble | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   when they talk   about Mumble they either talk about "Mumble" the client
   application or about "Mumble & Murmur" the whole voice chat application suite.
 adopt-info: mumble
+base: core18
 
 grade: stable
 confinement: strict
@@ -28,6 +29,32 @@ apps:
       - x11
 
 parts:
+  desktop-qt5:
+    build-packages:
+    - build-essential
+    - qtbase5-dev
+    - dpkg-dev
+    make-parameters:
+    - FLAVOR=qt5
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    stage-packages:
+    - libxkbcommon0
+    - ttf-ubuntu-font-family
+    - dmz-cursor-theme
+    - light-themes
+    - adwaita-icon-theme
+    - gnome-themes-standard
+    - shared-mime-info
+    - libqt5gui5
+    - libgdk-pixbuf2.0-0
+    - libqt5svg5
+    - try:
+      - appmenu-qt5
+    - locales-all
+    - xdg-user-dirs
+    - fcitx-frontend-qt5
   mumble:
     after: [desktop-qt5]
     plugin: qmake
@@ -56,10 +83,9 @@ parts:
       fi
       cp -R release/* $SNAPCRAFT_PART_INSTALL/bin
     build-packages:
-      - ice35-slice
-      - ice35-translators
+      - zeroc-ice-slice
       - libavahi-compat-libdnssd-dev
-      - libboost1.58-dev
+      - libboost1.62-dev
       - libcap-dev
       - libg15daemon-client-dev
       - libgl1-mesa-dev
@@ -75,7 +101,7 @@ parts:
       - libspeexdsp-dev
       - libssl-dev
       - libxi-dev
-      - libzeroc-ice35-dev
+      - libzeroc-ice-dev
       - protobuf-compiler
       - qt5-default
       - qttools5-dev-tools
@@ -99,3 +125,4 @@ parts:
       - libthai-data
       - libvorbis0a
       - libvorbisenc2
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,17 @@ parts:
     qt-version: qt5
     options:
       - CONFIG+=no-alsa no-oss no-server -recursive no-update packaged no-embed-qt-translations release bundled-celt symbols
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_released_tag="$(snap info mumble | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags)"
     override-build: |
       git submodule init
       git submodule update
@@ -44,7 +55,6 @@ parts:
         mkdir $SNAPCRAFT_PART_INSTALL/bin
       fi
       cp -R release/* $SNAPCRAFT_PART_INSTALL/bin
-      snapcraftctl set-version "$(git describe --tags)"
     build-packages:
       - ice35-slice
       - ice35-translators


### PR DESCRIPTION
Now mumble has a 1.3.0 stable releases we no longer need to build 1.2.x so we can do our usual scriptlet to figure out the right tag to build